### PR TITLE
Configurable smb conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ server.
 
 Puppet module to add Linux machines to a Windows Active Directory domain using Winbind.
 As this module fiddles with `smb.conf` it is not compatible with any other module
-that affects Samba operations.
+that affects Samba operations, unless a non default location for `smb.conf` is specified as 
+a parameter.
 
 This module installs the following facts:
 
@@ -92,7 +93,7 @@ not work with your Puppet environment. Optional boolean, defaults to `false`.
 
 Specify a custom disk location for the smb.conf file. Useful if another module is managing
 samba shares in the default configuration file.
- 
+
 ### `winbind_max_domain_connections`
 
 Specify the maximum number of simultaneous connections that the winbindd daemon

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ class { 'winbind':
   winbind_max_clients            => 500,
   osdata                         => false,
   machine_password_timeout       => 0,
+  smbconf_file                   => '/etc/samba/custom-smb.conf'
 }
 ```
 
@@ -87,6 +88,11 @@ Netbios name of the local machine. Optional, max 15 chars, defaults to `$::netbi
 Whether to enable Nagios check for domain membership. Has hard-coded parameters and may
 not work with your Puppet environment. Optional boolean, defaults to `false`.
 
+### `smbconf_file`
+
+Specify a custom disk location for the smb.conf file. Useful if another module is managing
+samba shares in the default configuration file.
+ 
 ### `winbind_max_domain_connections`
 
 Specify the maximum number of simultaneous connections that the winbindd daemon

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,11 +11,12 @@ class winbind (
   $winbind_max_domain_connections = 1,
   $winbind_max_clients = 200,
   $osdata = false,
+  $smbconf_file = '/etc/samba/smb.conf',
 ) {
 
   # Main samba config file
   file { 'smb.conf':
-    name    => '/etc/samba/smb.conf',
+    name    => $smbconf_file,
     mode    => '0644',
     owner   => 'root',
     group   => 'root',
@@ -45,7 +46,7 @@ class winbind (
 
   # Add the machine to the domain
   exec { 'add-to-domain':
-    command => "net ads join -U ${domainadminuser}%${domainadminpw} ${createcomputerarg} ${osdataarg}",
+    command => "net ads join -s ${smbconf_file} -U ${domainadminuser}%${domainadminpw} ${createcomputerarg} ${osdataarg}",
     onlyif  => "wbinfo --own-domain | grep -v ${domain}",
     path    => '/bin:/usr/bin',
     notify  => Service['winbind'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,13 @@ class winbind (
     require => [ File['smb.conf'], Package['samba-winbind-clients'] ],
   }
 
+  file_line { 'let-winbind-use-custom-smbconf-file':
+    path   => '/etc/sysconfig/samba',
+    line   => "WINBINDOPTIONS=\" -s ${smbconf_file}\"",
+    match  => '^WINBINDOPTIONS=.*$',
+    notify => Service['winbind'],
+  }
+
   # Start the winbind service
   service { 'winbind':
     ensure     => running,

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,6 @@
   ],
   "project_page": "https://github.com/djjudas21/puppet-winbind",
   "dependencies": [
-  
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 <5.0.0"},  
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,6 @@
   ],
   "project_page": "https://github.com/djjudas21/puppet-winbind",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 <5.0.0"},  
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 <5.0.0"}
   ]
 }


### PR DESCRIPTION
Hi Jonathan, 

The PR was only tested on CENTOS6, not 5. 

It includes a resource to make sure winning reads the custom smb config, was not entirely sure it would fit all use cases, maybe you could ponder about it for a bit? 


Best wishes, 

Eelco 
