### PR TITLE
Fix ads_domain fact complaining on systems where winbind is not installed

### DIFF
--- a/lib/facter/ads_domain.rb
+++ b/lib/facter/ads_domain.rb
@@ -2,6 +2,6 @@
 
 Facter.add("ads_domain") do
 	setcode do
-		%x{wbinfo --own-domain}.chomp
+		%x{wbinfo --own-domain 2>&1}.chomp
 	end
 end


### PR DESCRIPTION

I run winbind on RHEL6 systems and sssd on RHEL7 systems, so the RHEL7
are missing the wbinfo command that gives a nasty error in a puppet run

Could you please after merging my PRs release a new version on the puppet forge too? 