### PR TITLE
 Allow the customisation of a new set of keys in the smb.conf file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class winbind (
   $template_shell = '/bin/false',
   $template_homedir = '/home/%U',
   $osdata = false,
-  $uidrange = '15000-30000',
+  $uidrange = '16777216-33554431',
   $smbconf_file = '/etc/samba/smb.conf',
   
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,8 +10,14 @@ class winbind (
   $nagioschecks = false,
   $winbind_max_domain_connections = 1,
   $winbind_max_clients = 200,
+  $winbind_use_default_domain = 'no',
+  $winbind_offline_logon = 'false',
+  $template_shell = '/bin/false',
+  $template_homedir = '/home/%U',
   $osdata = false,
+  $uidrange = '15000-30000',
   $smbconf_file = '/etc/samba/smb.conf',
+  
 ) {
 
   # Main samba config file
@@ -36,7 +42,7 @@ class winbind (
 
   # If createcomputer is defined, prepend it with the argument
   if ($createcomputer) {
-    $createcomputerarg = "createcomputer=${createcomputer}"
+    $createcomputerarg = "createcomputer='${createcomputer}'"
   }
 
   # If $osdata=true, populate the string

--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -98,7 +98,8 @@
 	realm = <%= @realm %>
 	machine password timeout = <%= @machine_password_timeout %>
 
-	winbind use default domain = no
+	winbind use default domain = <%= @winbind_use_default_domain %>
+        winbind offline logon = <%= @winbind_offline_logon %>
 	winbind nested groups = Yes
 	winbind enum users = No
 	winbind enum groups = No
@@ -127,11 +128,12 @@
 # DNS Proxy - tells Samba whether or not to try to resolve NetBIOS names
 # via DNS nslookups.
 	
-	dns proxy = yes
+	dns proxy          = yes
 	name resolve order = host lmhosts
-	idmap uid = 16777216-33554431
-	idmap gid = 16777216-33554431
-	template shell = /bin/false
+	idmap uid          = <%= @uidrange %> 
+	idmap gid          = <%= @uidrange %>
+	template shell     = <%= @template_shell %>
+        template homedir   = <%= @template_homedir %> 
 
 #----------------------------- Winbind options -------------------------------
 # Winbind options


### PR DESCRIPTION

Care was taken to set the defaults to the previously hardcoded values, so
upgrading should not cause a log of pain.

