### PR TITLE
Restrict to Linux and only when wbinfo is present

### DIFF
--- a/lib/facter/ads_domain.rb
+++ b/lib/facter/ads_domain.rb
@@ -1,6 +1,10 @@
 # ads_domain.rb
 
 Facter.add("ads_domain") do
+	confine :kernel => :Linux
+        confine do
+                system("which wbinfo > /dev/null 2>&1")
+        end
 	setcode do
 		%x{wbinfo --own-domain 2>&1}.chomp
 	end


### PR DESCRIPTION
Avoid creating the fact when the OS is not Linux and wbinfo is not present