### PR TITLE
Restrict to Linux and only when wbinfo is present

### DIFF
--- a/lib/facter/winbind_version.rb
+++ b/lib/facter/winbind_version.rb
@@ -1,6 +1,10 @@
 # winbind_version.rb
 
 Facter.add("winbind_version") do
+	confine :kernel => :Linux
+        confine do
+                system("which wbinfo > /dev/null 2>&1")
+        end
 	setcode do
 		%x{wbinfo -V 2>&1 | cut -d ' ' -f 2 | cut -d '-' -f 1}.chomp
 	end


### PR DESCRIPTION
Avoid creating the fact when the OS is not Linux and wbinfo is not present