### PR TITLE
Make the default idmap backend and range configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@ class winbind (
   String $samba_client_package = 'samba-client',
   String $samba_winbind_package = 'samba-winbind',
   String $samba_conf_template = 'winbind/smb.conf.erb',
+  String $idmap_config_backend = 'tdb',
+  String $idmap_config_range = $uidrange,
 ) {
 
   # Main samba config file

--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -134,6 +134,8 @@
 	idmap gid          = <%= @uidrange %>
 	template shell     = <%= @template_shell %>
         template homedir   = <%= @template_homedir %> 
+  idmap config * : backend  = <%= @idmap_config_backend %>
+  idmap config * : range = <%= @idmap_config_range %>
 
 #----------------------------- Winbind options -------------------------------
 # Winbind options


### PR DESCRIPTION
We'd need to use the idmap_ad backend for our site, to keep uid's consistent between various Linux machines. This PR changes the winbind module to include settings for this in /etc/samba/smb.conf. The given defaults for backend and range should have no effect for existing users of this module, but allows us to specify 'idmap config * : backend = ad' in /etc/samba/smb.conf.