### PR TITLE
 Make sure createcomputerarg always has a value

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,4 @@
+---
+fixtures:
+  forge_modules:
+    stdlib: 'puppetlabs-stdlib'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 pkg/
-spec/fixures/
+spec/fixtures/
 .gemfile.lock
+/Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,122 @@
+---
+require: rubocop-rspec
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: '2.1'
+  Include:
+  - "./**/*.rb"
+  Exclude:
+  - bin/*
+  - ".vendor/**/*"
+  - "**/Gemfile"
+  - "**/Rakefile"
+  - pkg/**/*
+  - spec/fixtures/**/*
+  - vendor/**/*
+  - "**/Puppetfile"
+  - "**/Vagrantfile"
+  - "**/Guardfile"
+Metrics/LineLength:
+  Description: People have wide screens, use them.
+  Max: 200
+GetText/DecorateString:
+  Description: We don't want to decorate test output.
+  Exclude:
+  - spec/*
+RSpec/BeforeAfterAll:
+  Description: Beware of using after(:all) as it may cause state to leak between tests.
+    A necessary evil in acceptance testing.
+  Exclude:
+  - spec/acceptance/**/*.rb
+RSpec/HookArgument:
+  Description: Prefer explicit :each argument, matching existing module's style
+  EnforcedStyle: each
+Style/BlockDelimiters:
+  Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
+    be consistent then.
+  EnforcedStyle: braces_for_chaining
+Style/ClassAndModuleChildren:
+  Description: Compact style reduces the required amount of indentation.
+  EnforcedStyle: compact
+Style/EmptyElse:
+  Description: Enforce against empty else clauses, but allow `nil` for clarity.
+  EnforcedStyle: empty
+Style/FormatString:
+  Description: Following the main puppet project's style, prefer the % format format.
+  EnforcedStyle: percent
+Style/FormatStringToken:
+  Description: Following the main puppet project's style, prefer the simpler template
+    tokens over annotated ones.
+  EnforcedStyle: template
+Style/Lambda:
+  Description: Prefer the keyword for easier discoverability.
+  EnforcedStyle: literal
+Style/RegexpLiteral:
+  Description: Community preference. See https://github.com/voxpupuli/modulesync_config/issues/168
+  EnforcedStyle: percent_r
+Style/TernaryParentheses:
+  Description: Checks for use of parentheses around ternary conditions. Enforce parentheses
+    on complex expressions for better readability, but seriously consider breaking
+    it up.
+  EnforcedStyle: require_parentheses_when_complex
+Style/TrailingCommaInArguments:
+  Description: Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInLiteral:
+  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/SymbolArray:
+  Description: Using percent style obscures symbolic intent of array's contents.
+  EnforcedStyle: brackets
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+  - lib/puppet/parser/functions/**/*
+  - spec/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
+Style/CollectionMethods:
+  Enabled: true
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+Style/StringMethods:
+  Enabled: true
+Layout/EndOfLine:
+  Enabled: false
+Layout/IndentHeredoc:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+RSpec/MessageExpectation:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/SymbolProc:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'metadata-json-lint'
+gem 'puppet'
+gem 'puppetlabs_spec_helper'
+gem 'rake'
+gem 'rspec-puppet-facts'
+gem 'rubocop'
+gem 'rubocop-rspec'

--- a/Rakefile
+++ b/Rakefile
@@ -2,15 +2,15 @@ require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
 
-desc "Validate manifests, templates, and ruby files"
+desc 'Validate manifests, templates, and ruby files'
 task :validate do
   Dir['manifests/**/*.pp'].each do |manifest|
     sh "puppet parser validate --noop #{manifest}"
   end
-  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  Dir['spec/**/*.rb', 'lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ %r{spec/fixtures}
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/lib/facter/ads_domain.rb
+++ b/lib/facter/ads_domain.rb
@@ -1,9 +1,9 @@
 # ads_domain.rb
 
-Facter.add("ads_domain") do
-	confine :kernel => :Linux
-	confine { Facter::Core::Execution.which('wbinfo') }
-	setcode do
-		%x{wbinfo --own-domain 2>&1}.chomp
-	end
+Facter.add('ads_domain') do
+  confine kernel: :Linux
+  confine { Facter::Core::Execution.which('wbinfo') }
+  setcode do
+    `wbinfo --own-domain 2>&1`.chomp
+  end
 end

--- a/lib/facter/hostid.rb
+++ b/lib/facter/hostid.rb
@@ -1,4 +1,4 @@
 Facter.add(:hostid) do
   setcode 'hostid'
-  confine :kernel => %w{SunOS Linux AIX GNU/kFreeBSD}
+  confine kernel: ['SunOS', 'Linux', 'AIX', 'GNU/kFreeBSD']
 end

--- a/lib/facter/netbiosname.rb
+++ b/lib/facter/netbiosname.rb
@@ -1,13 +1,13 @@
 # Netbios names are limited to 15 chars and must be unique. We can't use
 # $hostname or $fqdn because these may be non-unique when truncated. Instead
-# we use the first 9 alphanumeric chars of the hostname and then append the 
+# we use the first 9 alphanumeric chars of the hostname and then append the
 # last 6 characters of the 8-character $hostid
 require 'facter'
-  Facter.add(:netbiosname) do
-    confine :kernel => :Linux
-    setcode do
-      hostid = Facter.value(:hostid)[2..7]
-      hostname = Facter.value(:hostname).gsub(/\W/, '')[0..8]
-      (hostname+hostid).upcase
-    end
+Facter.add(:netbiosname) do
+  confine kernel: :Linux
+  setcode do
+    hostid = Facter.value(:hostid)[2..7]
+    hostname = Facter.value(:hostname).gsub(%r{\W}, '')[0..8]
+    (hostname + hostid).upcase
   end
+end

--- a/lib/facter/winbind_version.rb
+++ b/lib/facter/winbind_version.rb
@@ -1,9 +1,9 @@
 # winbind_version.rb
 
-Facter.add("winbind_version") do
-	confine :kernel => :Linux
-	confine { Facter::Core::Execution.which('wbinfo') }
-	setcode do
-		%x{wbinfo -V 2>&1 | cut -d ' ' -f 2 | cut -d '-' -f 1}.chomp
-	end
+Facter.add('winbind_version') do
+  confine kernel: :Linux
+  confine { Facter::Core::Execution.which('wbinfo') }
+  setcode do
+    `wbinfo -V 2>&1 | cut -d ' ' -f 2 | cut -d '-' -f 1`.chomp
+  end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,9 @@ class winbind (
   if ($createcomputer != '') {
     $createcomputerarg = "createcomputer='${createcomputer}'"
   }
+  else {
+    $createcomputerarg = ''
+  }
 
   # If $osdata=true, populate the string
   if ($osdata) {

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
   ],
   "project_page": "https://github.com/djjudas21/puppet-winbind",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 <5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 <6.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,56 @@
 require 'spec_helper'
 describe 'winbind' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(clientcert: 'build')
+      end
+      let(:params) do
+        {
+          'domainadminuser' => 'admin',
+          'domainadminpw' => 'password',
+          'domain' => 'EXAMPLE',
+          'realm' => 'example.com',
+        }
+      end
 
-  context 'with defaults for all parameters' do
-    it { should contain_class('winbind') }
+      context 'with defaults for all parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file('smb.conf').with(
+            'mode' => '0644',
+            'owner' => 'root',
+            'group' => 'root',
+          ).that_requires('Package[samba-client]')
+        }
+        it {
+          is_expected.to contain_service('winbind').with(
+            'ensure' => 'running',
+            'enable' => true,
+            'hasstatus' => true,
+            'hasrestart' => true,
+          ).that_subscribes_to('File[smb.conf]')
+        }
+        it {
+          is_expected.to contain_file_line('let-winbind-use-custom-smbconf-file').that_notifies('Service[winbind]')
+        }
+        it {
+          is_expected.to contain_package('samba-client').with_ensure('installed')
+        }
+        it {
+          is_expected.to contain_package('samba-winbind-clients').with_ensure('installed')
+        }
+        it {
+          is_expected.to contain_package('samba-winbind').with_ensure('installed')
+        }
+        it {
+          is_expected.to contain_exec('add-to-domain').that_notifies('Service[winbind]')
+        }
+
+        it { is_expected.to contain_exec('add-to-domain').that_requires(['File[smb.conf]', 'Package[samba-winbind-clients]']) }
+        it { is_expected.to contain_service('winbind').that_requires(['File[smb.conf]', 'Package[samba-winbind]']) }
+        it { is_expected.to contain_file('smb.conf').that_notifies(['Exec[add-to-domain]', 'Service[winbind]']) }
+      end
+    end
   end
 end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,9 @@
+# Use default_module_facts.yml for module specific facts.
+#
+# Facts specified here will override the values provided by rspec-puppet-facts.
+---
+ipaddress: "172.16.254.254"
+is_pe: false
+macaddress: "AA:AA:AA:AA:AA:AA"
+sudoversion: 1.8.23
+netbiosname: example

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,46 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-require 'mocha'
+require 'puppetlabs_spec_helper/module_spec_helper'
 require 'puppet'
 require 'rspec'
-require 'spec/autorun'
+require 'rspec-puppet-facts'
 
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
+include RspecPuppetFacts
+
+default_facts = {
+  puppetversion: Puppet.version,
+  facterversion: Facter.version,
+}
+
+default_fact_files = [
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml')),
+]
+
+default_fact_files.each do |f|
+  next unless File.exist?(f) && File.readable?(f) && File.size?(f)
+
+  begin
+    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+  rescue => e
+    RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
+  end
 end
 
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
+RSpec.configure do |c|
+  c.default_facts = default_facts
+  c.before :each do
+    # set to strictest setting for testing
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = :warning
+  end
+  c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!(95)
+  end
 end


### PR DESCRIPTION
If no value for $createcomputer is provided, $createcomputerarg is not set. This results in the following error:
    Evaluation Error: Unknown variable: 'createcomputerarg'.
The commit 2cf5326 fixes that, by setting $createcomputerarg to an empty string, similar to how $osdataarg is handled.

Also part of this Pull Request are:
 - Updated dependency on Stdlib (5.x is the current version, and works fine with this module).
- As small as possible fixes to make most rake tasks work.
- Rubocop fixes (white space, quotation marks...).
- Rspec test that tests the base functionality of this module.
These 4 commits do not affect the functionality of the module, but are nice to haves. Of course I can rebase into 1 commit if that is preferred.